### PR TITLE
FIX: BuildAndRelease solo en PRs aprobados

### DIFF
--- a/.github/workflows/BuildAndRelease.yml
+++ b/.github/workflows/BuildAndRelease.yml
@@ -5,9 +5,12 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    types:
+      - closed
 
 jobs:
   coloursapi:
+    if: github.event.pull_request.merged == true  
     name: 🔨 Build ColoursAPI
     runs-on: windows-latest
     env:
@@ -37,6 +40,7 @@ jobs:
         server-dir: /recursosit_ftp/coloursapi.app.aprender.it_a0tfDHlR/wwwroot/
 
   coloursweb:
+    needs: coloursapi
     name: 🔨 Build ColoursWeb
     runs-on: windows-latest
     env:


### PR DESCRIPTION
Se realizó el fix para que el trigger sea solo en PRs aprobados.
Se agregó 'needs' condicional para los jobs siguientes.
Cierra issue #7 